### PR TITLE
Update make model input

### DIFF
--- a/analysis/model/make_model_input.R
+++ b/analysis/model/make_model_input.R
@@ -26,6 +26,7 @@ if (length(args) == 0) {
   # name <- "cohort_vax-sub_sex_female_preex_FALSE-asthma" # Testing sex group
   # name <- "cohort_vax-sub_age_40_59_preex_FALSE-pf" # Testing age group
   name <- "cohort_prevax-sub_ethnicity_asian_preex_FALSE-copd" # Check that the "asian" ethnicity is processing correctly
+  name <- "cohort_prevax-sub_smoking_never_preex_FALSE-pneumonia" # Check that the smoking subgroup is processing correctly
 } else {
   name <- args[[1]]
 }
@@ -55,6 +56,8 @@ print("Perform subgroup-specific manipulation")
 
 print(paste0("Make model input: ", analysis))
 
+check_for_subgroup <- (grepl("main", analysis)) # =1 if subgroup is main, =0 otherwise
+
 # Creating a pre-existing condition variable where appropriate
 if (grepl("preex", analysis)) {
   # True false indicator of preex
@@ -75,6 +78,7 @@ if (grepl("preex", analysis)) {
 
 # Make model input: main/sub_covidhistory ------------------------------------
 if (grepl("sub_covidhistory", analysis)) {
+  check_for_subgroup <- 1
   df <- pmi$input[pmi$input$sub_bin_covidhistory == TRUE, ] # Only selecting for this subgroup
 } else {
   df <- pmi$input[pmi$input$sub_bin_covidhistory == FALSE, ] # all other subgroups (inc. Main)
@@ -82,6 +86,7 @@ if (grepl("sub_covidhistory", analysis)) {
 
 # Make model input: sub_covidhospital ----------------------------------------
 if (grepl("sub_covidhospital", analysis)) {
+  check_for_subgroup <- 1
   covidhosp <- as.logical(gsub(
     ".*sub_covidhospital_",
     "",
@@ -111,6 +116,7 @@ if (grepl("sub_covidhospital", analysis)) {
 
 # Make model input: sub_sex_* ------------------------------------------------
 if (grepl("sub_sex_", analysis)) {
+  check_for_subgroup <- 1
   sex <- str_to_title(gsub(
     ".*sub_sex_",
     "",
@@ -121,6 +127,7 @@ if (grepl("sub_sex_", analysis)) {
 
 # Make model input: sub_age_* ------------------------------------------------
 if (grepl("sub_age_", analysis) == TRUE) {
+  check_for_subgroup <- 1
   min_age <- as.numeric(strsplit(
     gsub(".*sub_age_", "", analysis),
     split = "_"
@@ -137,6 +144,7 @@ if (grepl("sub_age_", analysis) == TRUE) {
 
 # Make model input: sub_ethnicity_* ------------------------------------------
 if (grepl("sub_ethnicity_", analysis) == TRUE) {
+  check_for_subgroup <- 1
   ethnicity <- str_to_title(gsub(
     "_",
     " ",
@@ -147,6 +155,11 @@ if (grepl("sub_ethnicity_", analysis) == TRUE) {
     )
   ))
   df <- df[df$cov_cat_ethnicity == ethnicity, ]
+}
+
+# Stop code if no subgroup/main analysis was correctly selected
+if (!check_for_subgroup) {
+  stop(paste0("Input: ", name, " did not undergo any subgroup analyses"))
 }
 
 # Save model output

--- a/analysis/model/make_model_input.R
+++ b/analysis/model/make_model_input.R
@@ -59,24 +59,6 @@ print(paste0("Make model input: ", analysis))
 
 check_for_subgroup <- (grepl("main", analysis)) # =1 if subgroup is main, =0 otherwise
 
-# Creating a pre-existing condition variable where appropriate
-if (grepl("preex", analysis)) {
-  # True false indicator of preex
-  preex <- gsub(
-    ".*preex_",
-    "",
-    analysis
-  )
-  # Remove preex string from analysis string
-  analysis <- gsub(
-    "_preex_.*",
-    "",
-    analysis
-  )
-  # Preserve the string we removed from active_analysis$analysis
-  preex_str <- paste0("_preex_", preex)
-}
-
 # Make model input: main/sub_covidhistory ------------------------------------
 if (grepl("sub_covidhistory", analysis)) {
   check_for_subgroup <- 1
@@ -158,9 +140,6 @@ if (grepl("sub_ethnicity_", analysis) == TRUE) {
   df <- df[df$cov_cat_ethnicity == ethnicity, ]
 }
 
-# Stop code if no subgroup/main analysis was correctly selected
-if (!check_for_subgroup) {
-  stop(paste0("Input: ", name, " did not undergo any subgroup filtering!"))
 # Make model input: sub_smoking_* ------------------------------------------
 if (grepl("sub_smoking_", analysis)) {
   smoking_label <- gsub(".*sub_smoking_", "", analysis)
@@ -178,6 +157,11 @@ if (grepl("sub_smoking_", analysis)) {
   }
 
   df <- df[df$cov_cat_smoking == smoking_code, ]
+}
+
+# Stop code if no subgroup/main analysis was correctly selected
+if (!check_for_subgroup) {
+  stop(paste0("Input: ", name, " did not undergo any subgroup filtering!"))
 }
 
 # Save model output

--- a/analysis/model/make_model_input.R
+++ b/analysis/model/make_model_input.R
@@ -159,7 +159,7 @@ if (grepl("sub_ethnicity_", analysis) == TRUE) {
 
 # Stop code if no subgroup/main analysis was correctly selected
 if (!check_for_subgroup) {
-  stop(paste0("Input: ", name, " did not undergo any subgroup analyses"))
+  stop(paste0("Input: ", name, " did not undergo any subgroup filtering!"))
 }
 
 # Save model output

--- a/analysis/model/make_model_input.R
+++ b/analysis/model/make_model_input.R
@@ -46,10 +46,11 @@ model_dir <- "output/model/"
 # check if sub directory exists, create if not
 fs::dir_create(here::here(model_dir))
 
-# Load and prepare data for analysis
+# Load and prepare data by selecting project-required columns and filtering the study population
 print("Load and prepare data for analysis")
 
-pmi <- prepare_model_input(name)
+pmi <- prepare_model_input(name, analysis)
+analysis <- pmi$analysis
 
 ## Perform subgroup-specific manipulation
 print("Perform subgroup-specific manipulation")
@@ -160,6 +161,23 @@ if (grepl("sub_ethnicity_", analysis) == TRUE) {
 # Stop code if no subgroup/main analysis was correctly selected
 if (!check_for_subgroup) {
   stop(paste0("Input: ", name, " did not undergo any subgroup filtering!"))
+# Make model input: sub_smoking_* ------------------------------------------
+if (grepl("sub_smoking_", analysis)) {
+  smoking_label <- gsub(".*sub_smoking_", "", analysis)
+
+  # Create a mapping from label to code
+  smoking_map <- c(
+    "never" = "N",
+    "ever" = "E",
+    "current" = "S"
+  )
+  smoking_code <- smoking_map[[smoking_label]]
+
+  if (is.null(smoking_code)) {
+    stop(paste0("Unrecognized smoking subgroup: ", smoking_label))
+  }
+
+  df <- df[df$cov_cat_smoking == smoking_code, ]
 }
 
 # Save model output

--- a/analysis/model/make_model_input.R
+++ b/analysis/model/make_model_input.R
@@ -142,21 +142,16 @@ if (grepl("sub_ethnicity_", analysis) == TRUE) {
 
 # Make model input: sub_smoking_* ------------------------------------------
 if (grepl("sub_smoking_", analysis)) {
-  smoking_label <- gsub(".*sub_smoking_", "", analysis)
-
-  # Create a mapping from label to code
-  smoking_map <- c(
-    "never" = "N",
-    "ever" = "E",
-    "current" = "S"
+  check_for_subgroup <- 1
+  smoking <- paste(
+    str_to_title(gsub(
+      ".*sub_smoking_",
+      "",
+      analysis
+    )),
+    "smoker"
   )
-  smoking_code <- smoking_map[[smoking_label]]
-
-  if (is.null(smoking_code)) {
-    stop(paste0("Unrecognized smoking subgroup: ", smoking_label))
-  }
-
-  df <- df[df$cov_cat_smoking == smoking_code, ]
+  df <- df[df$cov_cat_smoking == smoking, ]
 }
 
 # Stop code if no subgroup/main analysis was correctly selected


### PR DESCRIPTION
This PR makes the following updates:

1. Restrict to required population (based on preex_ indicator)

- This logic has been moved into the function `fn-prepare_model_input`, as we believe it sits between a cohort definition and a typical subgroup.

- This structure allows other repositories using similar logic to reuse or adapt this code.

⚠️ Note: The temp variable name used is `pop_bin_preex`, which should be derived from both `sub_bin_asthma_recent` and `sub_bin_copd_ever`. @venexia — apologies if I previously referred to it as a cov_ variable. It's not a pure history flag, as there are time-based criteria used in its definition.

2. Restrict to smoking subgroups (based on sub_smoking_* in analysis)

- This has been implemented in the main script `make_model_input.R`, matching the name in active_analyses (e.g. sub_smoking_current) to the full category in cov_cat_smoking (e.g. "Current smoker").

3. Update `end_date_outcome` and `end_date_exposure` based on definitions (initial revision finished but need your opinion @venexia )

- These updates account for cohort-specific variables: cens_date_dereg and out_date.
- As a result, they also impact the accuracy of `exp_date_covid` and `out_date_`.
- Since exp_date is used in earlier steps (e.g. Table 1), it might be more appropriate to apply these updates earlier in the pipeline — for example, within the dataset_clean stage using a new function (e.g. `fn-follow_up_dates_update`), sourced after `fn-ref`. Let me know your opinion. 

Thank you very much :)