### PR TITLE
Fix sub_cat_covidhospital and preex overwrite

### DIFF
--- a/analysis/model/fn-prepare_model_input.R
+++ b/analysis/model/fn-prepare_model_input.R
@@ -75,26 +75,20 @@ prepare_model_input <- function(name) {
 
   input <- input %>%
     dplyr::mutate(
-      out_date = as.Date(
-        ifelse(
-          out_date > end_date_outcome | out_date < index_date,
-          NA,
-          out_date
-        ),
-        origin = "1970-01-01"
+      out_date = replace(
+        out_date,
+        which(out_date > end_date_outcome | out_date < index_date),
+        NA
       ),
-      exp_date = as.Date(
-        ifelse(
-          exp_date > end_date_exposure | exp_date < index_date,
-          NA,
-          exp_date
-        ),
-        origin = "1970-01-01"
+      exp_date = replace(
+        exp_date,
+        which(exp_date > end_date_exposure | exp_date < index_date),
+        NA
       ),
-      sub_cat_covidhospital = ifelse(
-        is.na(exp_date),
-        "no_infection",
-        as.character(sub_cat_covidhospital)
+      sub_cat_covidhospital = replace(
+        sub_cat_covidhospital,
+        which(is.na(exp_date)),
+        "no_infection"
       )
     )
 

--- a/analysis/model/make_model_input.R
+++ b/analysis/model/make_model_input.R
@@ -94,31 +94,34 @@ if (grepl("sub_covidhospital", analysis)) {
     analysis
   ))
   str_covidhosp_cens <- ifelse(covidhosp, "non_hospitalised", "hospitalised")
-  df$end_date_outcome <- as.Date(
-    ifelse(
-      df$sub_cat_covidhospital == str_covidhosp_cens,
-      df$exp_date - 1,
-      df$end_date_outcome
+  df <- df %>%
+  dplyr::mutate(
+    end_date_outcome = as.Date(
+      ifelse(
+        sub_cat_covidhospital == str_covidhosp_cens,
+        exp_date - 1,
+        end_date_outcome
+      ),
+      origin = .Date(0)
     ),
-    origin = .Date(0)
-  )
-  df$exp_date <- as.Date(
-    ifelse(
-      df$sub_cat_covidhospital == str_covidhosp_cens,
-      NA_Date_,
-      df$exp_date
+    exp_date = as.Date(
+      ifelse(
+        sub_cat_covidhospital == str_covidhosp_cens,
+        NA_Date_,
+        exp_date
+      ),
+      origin = .Date(0)
     ),
-    origin = .Date(0)
-  )
-  df$out_date <- as.Date(
-    ifelse(
-      df$out_date > df$end_date_outcome,
-      NA_Date_,
-      df$out_date
-    ),
-    origin = .Date(0)
-  )
-  df <- df[df$end_date_outcome >= df$index_date, ]
+    out_date = as.Date(
+      ifelse(
+        out_date > end_date_outcome,
+        NA_Date_,
+        out_date
+      ),
+      origin = .Date(0)
+    )
+  ) %>%
+  dplyr::filter(end_date_outcome >= index_date)
 }
 
 # Make model input: sub_sex_* ------------------------------------------------

--- a/analysis/model/make_model_input.R
+++ b/analysis/model/make_model_input.R
@@ -66,6 +66,8 @@ if (grepl("preex", name)) {
     analysis
   )
   df <- pmi$input[pmi$input$sup_bin_preex == preex, ]
+} else {
+  df <- pmi$input
 }
 
 ## Perform subgroup-specific manipulation
@@ -78,9 +80,9 @@ check_for_subgroup <- (grepl("main", analysis)) # TRUE if subgroup is main, FALS
 # Make model input: main/sub_covidhistory ------------------------------------
 if (grepl("sub_covidhistory", analysis)) {
   check_for_subgroup <- TRUE
-  df <- pmi$input[pmi$input$sub_bin_covidhistory == TRUE, ] # Only selecting for this subgroup
+  df <- df[df$sub_bin_covidhistory == TRUE, ] # Only selecting for this subgroup
 } else {
-  df <- pmi$input[pmi$input$sub_bin_covidhistory == FALSE, ] # all other subgroups (inc. Main)
+  df <- df[df$sub_bin_covidhistory == FALSE, ] # all other subgroups (inc. Main)
 }
 
 # Make model input: sub_covidhospital ----------------------------------------

--- a/analysis/model/make_model_input.R
+++ b/analysis/model/make_model_input.R
@@ -192,4 +192,3 @@ print(paste0(
   name,
   ".rds"
 ))
-rm(df)

--- a/analysis/model/make_model_input.R
+++ b/analysis/model/make_model_input.R
@@ -94,21 +94,30 @@ if (grepl("sub_covidhospital", analysis)) {
     analysis
   ))
   str_covidhosp_cens <- ifelse(covidhosp, "non_hospitalised", "hospitalised")
-  df$end_date_outcome <- as.Date(ifelse(
-    df$sub_cat_covidhospital == str_covidhosp_cens,
-    df$exp_date - 1,
-    df$end_date_outcome
-  ))
-  df$exp_date <- as.Date(ifelse(
-    df$sub_cat_covidhospital == str_covidhosp_cens,
-    NA_Date_,
-    df$exp_date
-  ))
-  df$out_date <- as.Date(ifelse(
-    df$out_date > df$end_date_outcome,
-    NA_Date_,
-    df$out_date
-  ))
+  df$end_date_outcome <- as.Date(
+    ifelse(
+      df$sub_cat_covidhospital == str_covidhosp_cens,
+      df$exp_date - 1,
+      df$end_date_outcome
+    ),
+    origin = .Date(0)
+  )
+  df$exp_date <- as.Date(
+    ifelse(
+      df$sub_cat_covidhospital == str_covidhosp_cens,
+      NA_Date_,
+      df$exp_date
+    ),
+    origin = .Date(0)
+  )
+  df$out_date <- as.Date(
+    ifelse(
+      df$out_date > df$end_date_outcome,
+      NA_Date_,
+      df$out_date
+    ),
+    origin = .Date(0)
+  )
   df <- df[df$end_date_outcome >= df$index_date, ]
 }
 

--- a/analysis/model/make_model_input.R
+++ b/analysis/model/make_model_input.R
@@ -20,7 +20,7 @@ print("Specify arguments")
 args <- commandArgs(trailingOnly = TRUE)
 
 if (length(args) == 0) {
-  name <- "cohort_vax-sub_covidhospital_FALSE_preex_FALSE-copd"
+  name <- "cohort_prevax-sub_covidhospital_FALSE_preex_FALSE-asthma"
 } else {
   name <- args[[1]]
 }
@@ -92,24 +92,21 @@ if (grepl("sub_covidhospital", analysis)) {
     analysis
   ))
   str_covidhosp_cens <- ifelse(covidhosp, "non_hospitalised", "hospitalised")
-  df <- df %>%
-    dplyr::mutate(
-      end_date_outcome = replace(
-        end_date_outcome,
-        which(sub_cat_covidhospital == str_covidhosp_cens),
-        exp_date - 1
-      ),
-      exp_date = replace(
-        exp_date,
-        which(sub_cat_covidhospital == str_covidhosp_cens),
-        NA
-      ),
-      out_date = replace(
-        out_date,
-        which(out_date > end_date_outcome),
-        NA
-      )
-    )
+  df$end_date_outcome <- as.Date(ifelse(
+    df$sub_cat_covidhospital == str_covidhosp_cens,
+    df$exp_date - 1,
+    df$end_date_outcome
+  ))
+  df$exp_date <- as.Date(ifelse(
+    df$sub_cat_covidhospital == str_covidhosp_cens,
+    NA_Date_,
+    df$exp_date
+  ))
+  df$out_date <- as.Date(ifelse(
+    df$out_date > df$end_date_outcome,
+    NA_Date_,
+    df$out_date
+  ))
   df <- df[df$end_date_outcome >= df$index_date, ]
 }
 


### PR DESCRIPTION
- Further edits to address https://github.com/opensafely/post-covid-respiratory/issues/193, which caused failed jobs in the real data
- Fixed issue where preex filtering was ignored due to covidhistory overwriting the dataset (commit https://github.com/opensafely/post-covid-respiratory/pull/194/commits/b822be7db34e026955fe6b5dc8c0858a6430edc7)