### PR TITLE
Diagnose covariate overflow in Cox model for cohort_vax-main_preex_FALSE-pneumonia

### DIFF
--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -444,12 +444,16 @@ actions_list <- splice(
   ),
 
   ## Diagnosis: cross-tabulate covariates and correlations by survival intervals for cohort_vax-main_preex_FALSE-pneumonia
+
+  comment(glue(
+    "Diagnosis for overflow error in cohort_vax-main_preex_FALSE-pneumonia"
+  )),
+
   splice(
     unlist(
       lapply(
         c("cohort_vax-main_preex_FALSE-pneumonia"), # Add more cohorts to this vector as needed
         function(analysis_name) {
-          comment(glue("Diagnosis for overflow error in {analysis_name}"))
           action(
             name = glue("make_covariates_matrix-{analysis_name}"),
             run = glue(
@@ -471,11 +475,11 @@ actions_list <- splice(
 
               out <- list()
               for (interval in intervals) {
-                out[[glue("cross_tab_{interval}")]] <- glue(
-                  "output/diagnosis/variable_level_cross_counts_{interval}.csv"
+                out[[glue("crosstab-{analysis_name}-{interval}")]] <- glue(
+                  "output/diagnosis/cov_crosstab-{analysis_name}-{interval}.csv"
                 )
-                out[[glue("correlation_{interval}")]] <- glue(
-                  "output/diagnosis/variable_level_correlation_{interval}.csv"
+                out[[glue("correlation-{analysis_name}-{interval}")]] <- glue(
+                  "output/diagnosis/cov_correlation-{analysis_name}-{interval}.csv"
                 )
               }
               out

--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -425,7 +425,7 @@ actions_list <- splice(
       )
     )
   ),
-      
+
   ## Make absolute excess risk (AER) input
 
   comment("Make absolute excess risk (AER) input"),
@@ -433,10 +433,55 @@ actions_list <- splice(
   action(
     name = "make_aer_input",
     run = "r:latest analysis/aer/make_aer_input.R main",
-    needs = as.list(paste0("make_model_input-",active_analyses[grepl("-main",active_analyses$name),]$name)),
+    needs = as.list(paste0(
+      "make_model_input-",
+      active_analyses[grepl("-main", active_analyses$name), ]$name
+    )),
     moderately_sensitive = list(
       aer_input = glue("output/aer/aer_input-main.csv"),
       aer_input_midpoint6 = glue("output/aer/aer_input-main-midpoint6.csv")
+    )
+  ),
+
+  ## Diagnosis: cross-tabulate covariates by survival intervals for cohort_vax-main_preex_FALSE-pneumonia
+  comment(
+    "Generate covariate cross-tabulation matrices by survival interval for cohort_vax-main_preex_FALSE-pneumonia"
+  ),
+  action(
+    name = "make_covariates_matrix",
+    run = "r:latest analysis/diagnosis/covariates_matrix.R",
+    needs = list("make_model_input-cohort_vax-main_preex_FALSE-pneumonia"),
+    moderately_sensitive = list(
+      cross_tab_days0_1 = glue(
+        "output/diagnosis/variable_level_cross_counts_days0_1.csv"
+      ),
+      cross_tab_days1_7 = glue(
+        "output/diagnosis/variable_level_cross_counts_days1_7.csv"
+      ),
+      cross_tab_days7_14 = glue(
+        "output/diagnosis/variable_level_cross_counts_days7_14.csv"
+      ),
+      cross_tab_days14_28 = glue(
+        "output/diagnosis/variable_level_cross_counts_days14_28.csv"
+      ),
+      cross_tab_days28_56 = glue(
+        "output/diagnosis/variable_level_cross_counts_days28_56.csv"
+      ),
+      cross_tab_days56_84 = glue(
+        "output/diagnosis/variable_level_cross_counts_days56_84.csv"
+      ),
+      cross_tab_days84_183 = glue(
+        "output/diagnosis/variable_level_cross_counts_days84_183.csv"
+      ),
+      cross_tab_days183_365 = glue(
+        "output/diagnosis/variable_level_cross_counts_days183_365.csv"
+      ),
+      cross_tab_days365_730 = glue(
+        "output/diagnosis/variable_level_cross_counts_days365_730.csv"
+      ),
+      cross_tab_days730_1065 = glue(
+        "output/diagnosis/variable_level_cross_counts_days730_1065.csv"
+      )
     )
   )
 )

--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -443,46 +443,38 @@ actions_list <- splice(
     )
   ),
 
-  ## Diagnosis: cross-tabulate covariates by survival intervals for cohort_vax-main_preex_FALSE-pneumonia
+  ## Diagnosis: cross-tabulate covariates and correlations by survival intervals for cohort_vax-main_preex_FALSE-pneumonia
   comment(
-    "Generate covariate cross-tabulation matrices by survival interval for cohort_vax-main_preex_FALSE-pneumonia"
+    "Diagnosis for overflow error in cohort_vax-main_preex_FALSE-pneumonia"
   ),
   action(
     name = "make_covariates_matrix",
     run = "r:latest analysis/diagnosis/covariates_matrix.R",
     needs = list("make_model_input-cohort_vax-main_preex_FALSE-pneumonia"),
-    moderately_sensitive = list(
-      cross_tab_days0_1 = glue(
-        "output/diagnosis/variable_level_cross_counts_days0_1.csv"
-      ),
-      cross_tab_days1_7 = glue(
-        "output/diagnosis/variable_level_cross_counts_days1_7.csv"
-      ),
-      cross_tab_days7_14 = glue(
-        "output/diagnosis/variable_level_cross_counts_days7_14.csv"
-      ),
-      cross_tab_days14_28 = glue(
-        "output/diagnosis/variable_level_cross_counts_days14_28.csv"
-      ),
-      cross_tab_days28_56 = glue(
-        "output/diagnosis/variable_level_cross_counts_days28_56.csv"
-      ),
-      cross_tab_days56_84 = glue(
-        "output/diagnosis/variable_level_cross_counts_days56_84.csv"
-      ),
-      cross_tab_days84_183 = glue(
-        "output/diagnosis/variable_level_cross_counts_days84_183.csv"
-      ),
-      cross_tab_days183_365 = glue(
-        "output/diagnosis/variable_level_cross_counts_days183_365.csv"
-      ),
-      cross_tab_days365_730 = glue(
-        "output/diagnosis/variable_level_cross_counts_days365_730.csv"
-      ),
-      cross_tab_days730_1065 = glue(
-        "output/diagnosis/variable_level_cross_counts_days730_1065.csv"
+    moderately_sensitive = {
+      cutpoints_str <- active_analyses %>%
+        filter(name == "cohort_vax-main_preex_FALSE-pneumonia") %>%
+        pull(cut_points)
+
+      cutpoints_vax_unvax <- as.numeric(strsplit(cutpoints_str, ";")[[1]])
+      intervals <- paste0(
+        "days",
+        c(0, head(cutpoints_vax_unvax, -1)),
+        "_",
+        cutpoints_vax_unvax
       )
-    )
+
+      out <- list()
+      for (interval in intervals) {
+        out[[paste0("cross_tab_", interval)]] <- glue(
+          "output/diagnosis/variable_level_cross_counts_{interval}.csv"
+        )
+        out[[paste0("correlation_", interval)]] <- glue(
+          "output/diagnosis/variable_level_correlation_{interval}.csv"
+        )
+      }
+      out
+    }
   )
 )
 

--- a/analysis/diagnosis/covariates_matrix.R
+++ b/analysis/diagnosis/covariates_matrix.R
@@ -87,7 +87,7 @@ for (interval in time_intervals) {
   co_matrix_ordered <- mats$co[ordered_names, ordered_names]
   write.csv(
     as.data.frame(co_matrix_ordered),
-    paste0(diag_dir, "variable_level_cross_counts_", interval, ".csv"),
+    paste0(diag_dir, "cov_crosstab-", name, "-", interval, ".csv"),
     row.names = TRUE
   )
 
@@ -95,7 +95,7 @@ for (interval in time_intervals) {
     corr_matrix_ordered <- mats$corr[ordered_names, ordered_names]
     write.csv(
       as.data.frame(corr_matrix_ordered),
-      paste0(diag_dir, "variable_level_correlation_", interval, ".csv"),
+      paste0(diag_dir, "cov_correlation-", name, "-", interval, ".csv"),
       row.names = TRUE
     )
   }

--- a/analysis/diagnosis/covariates_matrix.R
+++ b/analysis/diagnosis/covariates_matrix.R
@@ -1,8 +1,8 @@
+library(plyr)
 library(dplyr)
 library(tidyr)
 library(readr)
 library(survival)
-library(plyr)
 
 # Define diagnosis output folder ------------------------------------------
 print("Creating diagnosis output folder")

--- a/analysis/diagnosis/covariates_matrix.R
+++ b/analysis/diagnosis/covariates_matrix.R
@@ -1,0 +1,83 @@
+library(dplyr)
+library(tidyr)
+library(readr)
+library(survival)
+library(plyr)
+
+# Define diagnosis output folder ------------------------------------------
+print("Creating diagnosis output folder")
+
+diag_dir <- "output/diagnosis/"
+fs::dir_create(here::here(diag_dir))
+
+# Load data and interval generator
+source("analysis/diagnosis/fn-generate_time_interval_indicators.R")
+df <- readRDS(
+  "output/model/model_input-cohort_vax-main_preex_FALSE-pneumonia.rds"
+)
+df_surv <- generate_time_interval_indicators(df)
+
+# Identify covariates and time intervals
+covariate_vars <- grep("^cov_(bin|cat)_", names(df), value = TRUE)
+time_intervals <- grep("^days", names(df_surv), value = TRUE)
+
+# Join covariates to survival data
+df_cov <- df_surv %>%
+  select(patient_id, all_of(time_intervals)) %>%
+  left_join(
+    df[, c("patient_id", all_of(covariate_vars))],
+    by = "patient_id"
+  )
+# Force all covariates to plain character
+df_cov <- df_cov %>%
+  mutate(across(all_of(covariate_vars), ~ as.character(as.vector(.))))
+
+# Function to compute co-occurrence matrix for a given time interval
+compute_co_matrix <- function(interval_name) {
+  df_subset <- df_cov %>%
+    filter(.data[[interval_name]] == 1) %>%
+    select(patient_id, all_of(covariate_vars))
+
+  # Drop factor/ordered classes for all covariates
+  for (v in names(df_subset)[names(df_subset) != "patient_id"]) {
+    df_subset[[v]] <- as.character(df_subset[[v]])
+  }
+
+  df_long <- df_subset %>%
+    pivot_longer(-patient_id, names_to = "variable", values_to = "value") %>%
+    mutate(level = paste0(variable, " = ", value)) %>%
+    select(patient_id, level)
+
+  df_wide <- df_long %>%
+    mutate(present = 1L) %>%
+    pivot_wider(names_from = level, values_from = present, values_fill = 0)
+
+  mat <- as.matrix(df_wide[, -1])
+  co_occurrence <- t(mat) %*% mat
+
+  return(co_occurrence)
+}
+
+# Generate and save co-occurrence matrix for each interval
+for (interval in time_intervals) {
+  co_matrix <- compute_co_matrix(interval)
+
+  # Optional: sort variable levels
+  ordered_names <- colnames(co_matrix) %>%
+    as.data.frame() %>%
+    setNames("full_name") %>%
+    mutate(
+      variable = sub(" = .*", "", full_name),
+      level = sub(".* = ", "", full_name)
+    ) %>%
+    arrange(variable, level) %>%
+    pull(full_name)
+
+  co_matrix_ordered <- co_matrix[ordered_names, ordered_names]
+
+  write.csv(
+    as.data.frame(co_matrix_ordered),
+    paste0(diag_dir, "variable_level_cross_counts_", interval, ".csv"),
+    row.names = TRUE
+  )
+}

--- a/analysis/diagnosis/covariates_matrix.R
+++ b/analysis/diagnosis/covariates_matrix.R
@@ -3,6 +3,16 @@ library(dplyr)
 library(tidyr)
 library(readr)
 library(survival)
+# Specify arguments ------------------------------------------------------------
+print("Specify arguments")
+
+args <- commandArgs(trailingOnly = TRUE)
+
+if (length(args) == 0) {
+  name <- "cohort_vax-main_preex_FALSE-pneumonia"
+} else {
+  name <- args[[1]]
+}
 
 # Define diagnosis output folder ------------------------------------------
 print("Creating diagnosis output folder")
@@ -12,9 +22,7 @@ fs::dir_create(here::here(diag_dir))
 
 # Load data and interval generator
 source("analysis/diagnosis/fn-generate_time_interval_indicators.R")
-df <- readRDS(
-  "output/model/model_input-cohort_vax-main_preex_FALSE-pneumonia.rds"
-)
+df <- readRDS(paste0("output/model/model_input-", name, ".rds"))
 df_surv <- generate_time_interval_indicators(df)
 
 # Identify covariates and time intervals

--- a/analysis/diagnosis/fn-generate_time_interval_indicators.R
+++ b/analysis/diagnosis/fn-generate_time_interval_indicators.R
@@ -1,0 +1,62 @@
+generate_time_interval_indicators <- function(df) {
+  # Set dates based on YAML
+  study_start <- as.Date("2021-06-01")
+  study_stop <- as.Date("2024-04-30")
+
+  # Extract exposure and outcome variable names from YAML
+  exposure_var <- "exp_date"
+  outcome_var <- "out_date"
+  cox_start_var <- "index_date"
+  cox_stop_var <- "end_date_outcome"
+
+  # Cut points (days since exposure) from YAML
+  cut_points <- as.numeric(c(1, 7, 14, 28, 56, 84, 183, 365, 730, 1065))
+
+  # Rename to generic names for compatibility
+  df <- dplyr::rename(df, exposure = !!exposure_var, outcome = !!outcome_var)
+
+  df$study_start <- study_start
+  df$study_stop <- study_stop
+
+  df$fup_start <- pmax(df$study_start, df[[cox_start_var]], na.rm = TRUE)
+  df$fup_stop <- pmin(
+    df$study_stop,
+    df[[cox_stop_var]],
+    df$outcome,
+    na.rm = TRUE
+  )
+
+  df <- df[df$fup_stop >= df$fup_start, ]
+
+  # Constrain exposure and outcome to valid follow-up
+  df$exposure[df$exposure < df$fup_start | df$exposure > df$fup_stop] <- NA
+  df$outcome[df$outcome < df$fup_start | df$outcome > df$fup_stop] <- NA
+
+  # Create outcome status flag
+  df$outcome_status <- df$outcome == df$fup_stop & !is.na(df$outcome)
+
+  # Generate episode labels
+  time_period_labels <- paste0(
+    "days",
+    c(0, cut_points[-length(cut_points)]),
+    "_",
+    cut_points
+  )
+
+  episode_labels <- data.frame(
+    episode = 0:length(cut_points),
+    time_period = c("days_pre", time_period_labels),
+    stringsAsFactors = FALSE
+  )
+
+  # Source the survival setup logic (assumed available)
+  source("analysis/diagnosis/fn-survival_data_setup.R")
+
+  df_surv <- survival_data_setup(
+    df = df,
+    cut_points = cut_points,
+    episode_labels = episode_labels
+  )
+
+  return(df_surv)
+}

--- a/analysis/diagnosis/fn-generate_time_interval_indicators.R
+++ b/analysis/diagnosis/fn-generate_time_interval_indicators.R
@@ -12,10 +12,10 @@ generate_time_interval_indicators <- function(df) {
   df$study_start <- study_start
   df$study_stop <- study_stop
 
-  df$fup_start <- pmax(df$study_start, df[[df$index_date]], na.rm = TRUE)
+  df$fup_start <- pmax(df$study_start, df$index_date, na.rm = TRUE)
   df$fup_stop <- pmin(
     df$study_stop,
-    df[[df$end_date_outcome]],
+    df$end_date_outcome,
     df$outcome,
     na.rm = TRUE
   )

--- a/analysis/diagnosis/fn-generate_time_interval_indicators.R
+++ b/analysis/diagnosis/fn-generate_time_interval_indicators.R
@@ -7,7 +7,7 @@ generate_time_interval_indicators <- function(df) {
   cut_points <- as.numeric(c(1, 7, 14, 28, 56, 84, 183, 365, 730, 1065))
 
   # Rename to generic names for compatibility
-  df <- dplyr::rename(df, exposure = !!df$exp_date, outcome = !!df$out_date)
+  df <- dplyr::rename(df, exposure = exp_date, outcome = out_date)
 
   df$study_start <- study_start
   df$study_stop <- study_stop

--- a/analysis/diagnosis/fn-survival_data_setup.R
+++ b/analysis/diagnosis/fn-survival_data_setup.R
@@ -1,0 +1,159 @@
+survival_data_setup <- function(df, cut_points, episode_labels) {
+    # Calculate where follow-up occurs in study period ---------------------------
+    print("Calculate where follow-up occurs in study period")
+
+    df$days_to_start <- as.numeric(df$fup_start - df$study_start)
+    df$days_to_end <- as.numeric(df$fup_stop - df$study_start) + 1
+
+    # Set survival data for the exposed ------------------------------------------
+    print("Set survival data for the exposed")
+
+    ## Filter data to exposed
+    print("Filter data to exposed")
+    exposed <- df[!is.na(df$exposure), ]
+
+    ## Calculate days to exposure
+    print("Calculate days to exposure")
+    exposed$days_to_exp <- as.numeric(exposed$exposure - exposed$study_start)
+
+    ## Put into survival format
+    print("Put into survival format (dataset d1)")
+    d1 <- exposed[,
+        !(colnames(exposed) %in%
+            c("days_to_start", "days_to_exp", "days_to_end", "outcome_status"))
+    ]
+    print(summary(d1))
+
+    print("Put into survival format (dataset d2)")
+    d2 <- exposed[, c(
+        "patient_id",
+        "days_to_start",
+        "days_to_exp",
+        "days_to_end",
+        "outcome_status"
+    )]
+    print(summary(d2))
+
+    print("Put into survival format (tmerge)")
+    exposed <- survival::tmerge(
+        data1 = d1,
+        data2 = d2,
+        id = patient_id,
+        outcome_status = event(days_to_end, outcome_status),
+        tstart = days_to_start,
+        tstop = days_to_end,
+        exposure_status = tdc(days_to_exp)
+    )
+    print(summary(exposed))
+
+    # Split post-exposure time for the exposed -----------------------------------
+    print("Split post-exposure time for the exposed")
+
+    ## Filter to post-exposure data
+    print("Filter to post-exposure data")
+    exposed_post <- exposed[exposed$exposure_status == 1, ]
+
+    ## Format tstart and tstop
+    print("Format tstart and tstop")
+    exposed_post <- dplyr::rename(exposed_post, t0 = tstart, t = tstop)
+    exposed_post$tstart <- 0
+    exposed_post$tstop <- exposed_post$t - exposed_post$t0
+
+    ## Implement post-exposure cut points
+    print("Implement post-exposure cut points")
+
+    print(summary(exposed_post))
+
+    exposed_post <- survival::survSplit(
+        Surv(tstop, outcome_status) ~ .,
+        exposed_post,
+        cut = cut_points,
+        episode = "episode"
+    )
+
+    print(summary(exposed_post))
+
+    ## Account for pre-exposure time
+    print("Account for pre-exposure time")
+
+    exposed_post$tstart <- exposed_post$tstart + exposed_post$t0
+    exposed_post$tstop <- exposed_post$tstop + exposed_post$t0
+    exposed_post[, c("t0", "t")] <- NULL
+
+    print(summary(exposed_post))
+
+    # Combine pre- and post-exposure time for the exposed ------------------------
+    print("Combine pre- and post-exposure time for the exposed")
+
+    ## Filter to pre-exposure data
+    print("Filter to pre-exposure data")
+    exposed_pre <- exposed[exposed$exposure_status == 0, ]
+
+    if (nrow(exposed_pre) > 0) {
+        ## Set pre-exposure to be episode 0
+        print("Set pre-exposure to be episode 0")
+        exposed_pre$episode <- 0
+        print(summary(exposed_pre))
+
+        ## Bind pre- and post-exposure time
+        print("Bind pre- and post-exposure time")
+        exposed <- plyr::rbind.fill(exposed_pre, exposed_post)
+    } else {
+        ## No pre-exposure time so exposed = post-exposure time only
+        print("No pre-exposure time so exposed = post-exposure time only")
+        exposed <- exposed_post
+    }
+
+    print(summary(exposed))
+
+    # Set survival data for the unexposed ----------------------------------------
+    print("Set survival data for the unexposed")
+
+    ## Filter data to unexposed
+    print("Filter data to unexposed")
+    unexposed <- df[is.na(df$exposure), ]
+
+    ## Rename variables to survival variable names
+    print("Rename variables to survival variable names")
+
+    unexposed <- dplyr::rename(
+        unexposed,
+        "tstart" = "days_to_start",
+        "tstop" = "days_to_end"
+    )
+
+    unexposed$exposure_status <- c(0)
+    unexposed$episode <- c(0)
+    unexposed$outcome_status <- as.numeric(unexposed$outcome_status)
+
+    print(summary(unexposed))
+
+    # Combine exposed and unexposed individuals ----------------------------------
+    print("Combine exposed and unexposed individuals")
+
+    exposed <- exposed[, intersect(colnames(unexposed), colnames(exposed))]
+    unexposed <- unexposed[, intersect(colnames(unexposed), colnames(exposed))]
+    df <- rbind(exposed, unexposed)
+
+    print(summary(df))
+
+    # Add indicators for episode -------------------------------------------------
+    print("Add indicators for episode")
+
+    for (i in 1:max(episode_labels$episode)) {
+        preserve_cols <- colnames(df)
+
+        df$tmp <- as.numeric(df$episode == i)
+
+        colnames(df) <- c(
+            preserve_cols,
+            episode_labels[episode_labels$episode == i, ]$time_period
+        )
+    }
+
+    print(summary(df))
+
+    # Return dataset -------------------------------------------------------------
+
+    return(df)
+}

--- a/project.yaml
+++ b/project.yaml
@@ -7619,30 +7619,32 @@ actions:
         aer_input: output/aer/aer_input-main.csv
         aer_input_midpoint6: output/aer/aer_input-main-midpoint6.csv
 
+  ## Diagnosis for overflow error in cohort_vax-main_preex_FALSE-pneumonia 
+
   make_covariates_matrix-cohort_vax-main_preex_FALSE-pneumonia:
     run: r:latest analysis/diagnosis/covariates_matrix.R cohort_vax-main_preex_FALSE-pneumonia
     needs:
     - make_model_input-cohort_vax-main_preex_FALSE-pneumonia
     outputs:
       moderately_sensitive:
-        cross_tab_days0_1: output/diagnosis/variable_level_cross_counts_days0_1.csv
-        correlation_days0_1: output/diagnosis/variable_level_correlation_days0_1.csv
-        cross_tab_days1_7: output/diagnosis/variable_level_cross_counts_days1_7.csv
-        correlation_days1_7: output/diagnosis/variable_level_correlation_days1_7.csv
-        cross_tab_days7_14: output/diagnosis/variable_level_cross_counts_days7_14.csv
-        correlation_days7_14: output/diagnosis/variable_level_correlation_days7_14.csv
-        cross_tab_days14_28: output/diagnosis/variable_level_cross_counts_days14_28.csv
-        correlation_days14_28: output/diagnosis/variable_level_correlation_days14_28.csv
-        cross_tab_days28_56: output/diagnosis/variable_level_cross_counts_days28_56.csv
-        correlation_days28_56: output/diagnosis/variable_level_correlation_days28_56.csv
-        cross_tab_days56_84: output/diagnosis/variable_level_cross_counts_days56_84.csv
-        correlation_days56_84: output/diagnosis/variable_level_correlation_days56_84.csv
-        cross_tab_days84_183: output/diagnosis/variable_level_cross_counts_days84_183.csv
-        correlation_days84_183: output/diagnosis/variable_level_correlation_days84_183.csv
-        cross_tab_days183_365: output/diagnosis/variable_level_cross_counts_days183_365.csv
-        correlation_days183_365: output/diagnosis/variable_level_correlation_days183_365.csv
-        cross_tab_days365_730: output/diagnosis/variable_level_cross_counts_days365_730.csv
-        correlation_days365_730: output/diagnosis/variable_level_correlation_days365_730.csv
-        cross_tab_days730_1065: output/diagnosis/variable_level_cross_counts_days730_1065.csv
-        correlation_days730_1065: output/diagnosis/variable_level_correlation_days730_1065.csv
+        crosstab-cohort_vax-main_preex_FALSE-pneumonia-days0_1: output/diagnosis/cov_crosstab-cohort_vax-main_preex_FALSE-pneumonia-days0_1.csv
+        correlation-cohort_vax-main_preex_FALSE-pneumonia-days0_1: output/diagnosis/cov_correlation-cohort_vax-main_preex_FALSE-pneumonia-days0_1.csv
+        crosstab-cohort_vax-main_preex_FALSE-pneumonia-days1_7: output/diagnosis/cov_crosstab-cohort_vax-main_preex_FALSE-pneumonia-days1_7.csv
+        correlation-cohort_vax-main_preex_FALSE-pneumonia-days1_7: output/diagnosis/cov_correlation-cohort_vax-main_preex_FALSE-pneumonia-days1_7.csv
+        crosstab-cohort_vax-main_preex_FALSE-pneumonia-days7_14: output/diagnosis/cov_crosstab-cohort_vax-main_preex_FALSE-pneumonia-days7_14.csv
+        correlation-cohort_vax-main_preex_FALSE-pneumonia-days7_14: output/diagnosis/cov_correlation-cohort_vax-main_preex_FALSE-pneumonia-days7_14.csv
+        crosstab-cohort_vax-main_preex_FALSE-pneumonia-days14_28: output/diagnosis/cov_crosstab-cohort_vax-main_preex_FALSE-pneumonia-days14_28.csv
+        correlation-cohort_vax-main_preex_FALSE-pneumonia-days14_28: output/diagnosis/cov_correlation-cohort_vax-main_preex_FALSE-pneumonia-days14_28.csv
+        crosstab-cohort_vax-main_preex_FALSE-pneumonia-days28_56: output/diagnosis/cov_crosstab-cohort_vax-main_preex_FALSE-pneumonia-days28_56.csv
+        correlation-cohort_vax-main_preex_FALSE-pneumonia-days28_56: output/diagnosis/cov_correlation-cohort_vax-main_preex_FALSE-pneumonia-days28_56.csv
+        crosstab-cohort_vax-main_preex_FALSE-pneumonia-days56_84: output/diagnosis/cov_crosstab-cohort_vax-main_preex_FALSE-pneumonia-days56_84.csv
+        correlation-cohort_vax-main_preex_FALSE-pneumonia-days56_84: output/diagnosis/cov_correlation-cohort_vax-main_preex_FALSE-pneumonia-days56_84.csv
+        crosstab-cohort_vax-main_preex_FALSE-pneumonia-days84_183: output/diagnosis/cov_crosstab-cohort_vax-main_preex_FALSE-pneumonia-days84_183.csv
+        correlation-cohort_vax-main_preex_FALSE-pneumonia-days84_183: output/diagnosis/cov_correlation-cohort_vax-main_preex_FALSE-pneumonia-days84_183.csv
+        crosstab-cohort_vax-main_preex_FALSE-pneumonia-days183_365: output/diagnosis/cov_crosstab-cohort_vax-main_preex_FALSE-pneumonia-days183_365.csv
+        correlation-cohort_vax-main_preex_FALSE-pneumonia-days183_365: output/diagnosis/cov_correlation-cohort_vax-main_preex_FALSE-pneumonia-days183_365.csv
+        crosstab-cohort_vax-main_preex_FALSE-pneumonia-days365_730: output/diagnosis/cov_crosstab-cohort_vax-main_preex_FALSE-pneumonia-days365_730.csv
+        correlation-cohort_vax-main_preex_FALSE-pneumonia-days365_730: output/diagnosis/cov_correlation-cohort_vax-main_preex_FALSE-pneumonia-days365_730.csv
+        crosstab-cohort_vax-main_preex_FALSE-pneumonia-days730_1065: output/diagnosis/cov_crosstab-cohort_vax-main_preex_FALSE-pneumonia-days730_1065.csv
+        correlation-cohort_vax-main_preex_FALSE-pneumonia-days730_1065: output/diagnosis/cov_correlation-cohort_vax-main_preex_FALSE-pneumonia-days730_1065.csv
 

--- a/project.yaml
+++ b/project.yaml
@@ -7619,3 +7619,24 @@ actions:
         aer_input: output/aer/aer_input-main.csv
         aer_input_midpoint6: output/aer/aer_input-main-midpoint6.csv
 
+  ## Generate covariate cross-tabulation matrices by survival interval for cohort_vax-main_preex_FALSE-pneumonia
+
+    
+
+  make_covariates_matrix:
+    run: r:latest analysis/diagnosis/covariates_matrix.R
+    needs:
+    - make_model_input-cohort_vax-main_preex_FALSE-pneumonia
+    outputs:
+      moderately_sensitive:
+        cross_tab_days0_1: output/diagnosis/variable_level_cross_counts_days0_1.csv
+        cross_tab_days1_7: output/diagnosis/variable_level_cross_counts_days1_7.csv
+        cross_tab_days7_14: output/diagnosis/variable_level_cross_counts_days7_14.csv
+        cross_tab_days14_28: output/diagnosis/variable_level_cross_counts_days14_28.csv
+        cross_tab_days28_56: output/diagnosis/variable_level_cross_counts_days28_56.csv
+        cross_tab_days56_84: output/diagnosis/variable_level_cross_counts_days56_84.csv
+        cross_tab_days84_183: output/diagnosis/variable_level_cross_counts_days84_183.csv
+        cross_tab_days183_365: output/diagnosis/variable_level_cross_counts_days183_365.csv
+        cross_tab_days365_730: output/diagnosis/variable_level_cross_counts_days365_730.csv
+        cross_tab_days730_1065: output/diagnosis/variable_level_cross_counts_days730_1065.csv
+

--- a/project.yaml
+++ b/project.yaml
@@ -7619,9 +7619,7 @@ actions:
         aer_input: output/aer/aer_input-main.csv
         aer_input_midpoint6: output/aer/aer_input-main-midpoint6.csv
 
-  ## Generate covariate cross-tabulation matrices by survival interval for cohort_vax-main_preex_FALSE-pneumonia
-
-    
+  ## Diagnosis for overflow error in cohort_vax-main_preex_FALSE-pneumonia 
 
   make_covariates_matrix:
     run: r:latest analysis/diagnosis/covariates_matrix.R
@@ -7630,13 +7628,23 @@ actions:
     outputs:
       moderately_sensitive:
         cross_tab_days0_1: output/diagnosis/variable_level_cross_counts_days0_1.csv
+        correlation_days0_1: output/diagnosis/variable_level_correlation_days0_1.csv
         cross_tab_days1_7: output/diagnosis/variable_level_cross_counts_days1_7.csv
+        correlation_days1_7: output/diagnosis/variable_level_correlation_days1_7.csv
         cross_tab_days7_14: output/diagnosis/variable_level_cross_counts_days7_14.csv
+        correlation_days7_14: output/diagnosis/variable_level_correlation_days7_14.csv
         cross_tab_days14_28: output/diagnosis/variable_level_cross_counts_days14_28.csv
+        correlation_days14_28: output/diagnosis/variable_level_correlation_days14_28.csv
         cross_tab_days28_56: output/diagnosis/variable_level_cross_counts_days28_56.csv
+        correlation_days28_56: output/diagnosis/variable_level_correlation_days28_56.csv
         cross_tab_days56_84: output/diagnosis/variable_level_cross_counts_days56_84.csv
+        correlation_days56_84: output/diagnosis/variable_level_correlation_days56_84.csv
         cross_tab_days84_183: output/diagnosis/variable_level_cross_counts_days84_183.csv
+        correlation_days84_183: output/diagnosis/variable_level_correlation_days84_183.csv
         cross_tab_days183_365: output/diagnosis/variable_level_cross_counts_days183_365.csv
+        correlation_days183_365: output/diagnosis/variable_level_correlation_days183_365.csv
         cross_tab_days365_730: output/diagnosis/variable_level_cross_counts_days365_730.csv
+        correlation_days365_730: output/diagnosis/variable_level_correlation_days365_730.csv
         cross_tab_days730_1065: output/diagnosis/variable_level_cross_counts_days730_1065.csv
+        correlation_days730_1065: output/diagnosis/variable_level_correlation_days730_1065.csv
 

--- a/project.yaml
+++ b/project.yaml
@@ -7619,10 +7619,8 @@ actions:
         aer_input: output/aer/aer_input-main.csv
         aer_input_midpoint6: output/aer/aer_input-main-midpoint6.csv
 
-  ## Diagnosis for overflow error in cohort_vax-main_preex_FALSE-pneumonia 
-
-  make_covariates_matrix:
-    run: r:latest analysis/diagnosis/covariates_matrix.R
+  make_covariates_matrix-cohort_vax-main_preex_FALSE-pneumonia:
+    run: r:latest analysis/diagnosis/covariates_matrix.R cohort_vax-main_preex_FALSE-pneumonia
     needs:
     - make_model_input-cohort_vax-main_preex_FALSE-pneumonia
     outputs:


### PR DESCRIPTION
This PR adds a diagnostic script to generate cross-tabulation matrices of covariates by survival intervals. It is intended to help identify potential sparse combinations of covariates that may be causing the “covariate overflow” error in the cox_ipw-cohort_vax-main_preex_FALSE-pneumonia model.

The output matrices will support inspection of low-frequency cells (e.g., rare combinations within time intervals such as days0_1, days1_7, etc.).