### PR TITLE
Diagnosis table2 v1

### DIFF
--- a/analysis/make_output/make_aer_input.R
+++ b/analysis/make_output/make_aer_input.R
@@ -119,17 +119,11 @@ for (i in 1:nrow(active_analyses)) {
                 c("patient_id", "exp_date", "end_date_outcome")
             ]
 
-            exposed <- exposed %>%
-                dplyr::mutate(
-                    fup_start = exp_date,
-                    fup_end = end_date_outcome
-                )
-
-            exposed <- exposed[exposed$fup_start <= exposed$fup_end, ]
+            exposed <- exposed[exposed$fup_start <= exposed$end_date_outcome, ]
 
             exposed <- exposed %>%
                 dplyr::mutate(
-                    person_days = as.numeric((fup_end - fup_start)) + 1
+                    person_days = as.numeric((end_date_outcome - exp_date)) + 1
                 )
 
             ## Make unexposed subset -------------------------------------------------

--- a/analysis/make_output/make_aer_input.R
+++ b/analysis/make_output/make_aer_input.R
@@ -146,7 +146,7 @@ for (i in 1:nrow(active_analyses)) {
             unexposed <- unexposed %>%
                 dplyr::mutate(
                     fup_start = index_date,
-                    fup_end = min(
+                    fup_end = pmin(
                         exp_date - 1,
                         end_date_outcome,
                         na.rm = TRUE

--- a/analysis/make_output/make_aer_input.R
+++ b/analysis/make_output/make_aer_input.R
@@ -119,7 +119,7 @@ for (i in 1:nrow(active_analyses)) {
                 c("patient_id", "exp_date", "end_date_outcome")
             ]
 
-            exposed <- exposed[exposed$fup_start <= exposed$end_date_outcome, ]
+            exposed <- exposed[exposed$exp_date <= exposed$end_date_outcome, ]
 
             exposed <- exposed %>%
                 dplyr::mutate(

--- a/analysis/table2/table2.R
+++ b/analysis/table2/table2.R
@@ -127,7 +127,7 @@ for (i in 1:nrow(active_analyses)) {
   unexposed <- unexposed %>%
     dplyr::mutate(
       fup_start = index_date,
-      fup_end = min(exp_date - 1, end_date_outcome, na.rm = TRUE),
+      fup_end = pmin(exp_date - 1, end_date_outcome, na.rm = TRUE),
       out_date = replace(out_date, which(out_date > fup_end), NA)
     )
 

--- a/analysis/table2/table2.R
+++ b/analysis/table2/table2.R
@@ -100,17 +100,11 @@ for (i in 1:nrow(active_analyses)) {
     c("patient_id", "exp_date", "out_date", "end_date_outcome")
   ]
 
-  exposed <- exposed %>%
-    dplyr::mutate(
-      fup_start = exp_date,
-      fup_end = end_date_outcome
-    )
-
-  exposed <- exposed[exposed$fup_start <= exposed$fup_end, ]
+  exposed <- exposed[exposed$exp_date <= exposed$end_date_outcome, ]
 
   exposed <- exposed %>%
     dplyr::mutate(
-      person_days = as.numeric((fup_end - fup_start)) + 1
+      person_days = as.numeric((end_date_outcome - exp_date)) + 1
     )
 
   ## Make unexposed subset -----------------------------------------------------

--- a/analysis/table2/table2.R
+++ b/analysis/table2/table2.R
@@ -34,9 +34,7 @@ print('Load active analyses')
 
 active_analyses <- readr::read_rds("lib/active_analyses.rds")
 
-table2_names <- gsub(
-  "out_date_",
-  "",
+table2_names <-
   unique(
     active_analyses[
       active_analyses$cohort ==
@@ -45,7 +43,6 @@ table2_names <- gsub(
         },
     ]$name
   )
-)
 
 table2_names <- table2_names[
   grepl("-main", table2_names) |
@@ -95,23 +92,6 @@ for (i in 1:nrow(active_analyses)) {
     "end_date_outcome"
   )]
 
-  # Remove exposures and outcomes outside follow-up ----------------------------
-  print("Remove exposures and outcomes outside follow-up")
-
-  df <- df %>%
-    dplyr::mutate(
-      exposure = replace(
-        exp_date,
-        which(exp_date > end_date_exposure | exp_date < index_date),
-        NA
-      ),
-      outcome = replace(
-        out_date,
-        which(out_date > end_date_outcome | out_date < index_date),
-        NA
-      )
-    )
-
   ## Make exposed subset -------------------------------------------------------
   print('Make exposed subset')
 
@@ -123,13 +103,15 @@ for (i in 1:nrow(active_analyses)) {
   exposed <- exposed %>%
     dplyr::mutate(
       fup_start = exp_date,
-      fup_end = min(end_date_outcome, out_date, na.rm = TRUE)
+      fup_end = end_date_outcome
     )
 
   exposed <- exposed[exposed$fup_start <= exposed$fup_end, ]
 
   exposed <- exposed %>%
-    dplyr::mutate(person_days = as.numeric((fup_end - fup_start)) + 1)
+    dplyr::mutate(
+      person_days = as.numeric((fup_end - fup_start)) + 1
+    )
 
   ## Make unexposed subset -----------------------------------------------------
   print('Make unexposed subset')
@@ -145,14 +127,16 @@ for (i in 1:nrow(active_analyses)) {
   unexposed <- unexposed %>%
     dplyr::mutate(
       fup_start = index_date,
-      fup_end = min(exp_date - 1, end_date_outcome, out_date, na.rm = TRUE),
+      fup_end = min(exp_date - 1, end_date_outcome, na.rm = TRUE),
       out_date = replace(out_date, which(out_date > fup_end), NA)
     )
 
   unexposed <- unexposed[unexposed$fup_start <= unexposed$fup_end, ]
 
   unexposed <- unexposed %>%
-    dplyr::mutate(person_days = as.numeric((fup_end - fup_start)) + 1)
+    dplyr::mutate(
+      person_days = as.numeric((fup_end - fup_start)) + 1
+    )
 
   ## Append to table 2 ---------------------------------------------------------
   print('Append to table 2')
@@ -164,10 +148,15 @@ for (i in 1:nrow(active_analyses)) {
     outcome = active_analyses$outcome[i],
     analysis = active_analyses$analysis[i],
     unexposed_person_days = sum(unexposed$person_days),
-    unexposed_events = nrow(unexposed[!is.na(unexposed$out_date), ]),
+    unexposed_events = nrow(unexposed[
+      !is.na(unexposed$out_date),
+    ]),
     exposed_person_days = sum(exposed$person_days, na.rm = TRUE),
-    exposed_events = nrow(exposed[!is.na(exposed$out_date), ]),
-    total_person_days = sum(unexposed$person_days) + sum(exposed$person_days),
+    exposed_events = nrow(exposed[
+      !is.na(exposed$out_date),
+    ]),
+    total_person_days = sum(unexposed$person_days) +
+      sum(exposed$person_days, na.rm = TRUE),
     total_events = nrow(unexposed[!is.na(unexposed$out_date), ]) +
       nrow(exposed[!is.na(exposed$out_date), ]),
     day0_events = nrow(exposed[


### PR DESCRIPTION
This PR is trying to make table2 run on real data:

- A bug was fixed where `min()` for `fup_end` applied to the entire dataframe instead of row-wise, causing `fup_end` = `index_date` in the `unexposed data frame`. This fix applies to both Table 2 and AER. 
- The Table 2 script was also tidied for consistency with AER.