### PR TITLE
Remove any hard coding of days

### DIFF
--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -309,7 +309,7 @@ apply_stata_model_function <- function(
     action(
       name = glue("stata_cox_ipw-{name}"),
       run = "stata-mp:latest analysis/model/cox_model.do",
-      arguments = c(name),
+      arguments = c(name, cut_points, study_start),
       needs = c(as.list(glue("ready-{name}"))),
       moderately_sensitive = list(
         model_output = glue("output/model/stata_model_output-{name}.csv")

--- a/project.yaml
+++ b/project.yaml
@@ -7204,6 +7204,7 @@ actions:
 
   stata_cox_ipw-cohort_prevax-main_preex_FALSE-asthma:
     run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-main_preex_FALSE-asthma
+      1;28;183;365;730;1095;1460;1825;1979 2020-01-01
     needs:
     - ready-cohort_prevax-main_preex_FALSE-asthma
     outputs:
@@ -7227,6 +7228,7 @@ actions:
 
   stata_cox_ipw-cohort_prevax-main_preex_FALSE-ild:
     run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-main_preex_FALSE-ild
+      1;28;183;365;730;1095;1460;1825;1979 2020-01-01
     needs:
     - ready-cohort_prevax-main_preex_FALSE-ild
     outputs:
@@ -7250,6 +7252,7 @@ actions:
 
   stata_cox_ipw-cohort_prevax-main_preex_FALSE-pneumonia:
     run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-main_preex_FALSE-pneumonia
+      1;28;183;365;730;1095;1460;1825;1979 2020-01-01
     needs:
     - ready-cohort_prevax-main_preex_FALSE-pneumonia
     outputs:
@@ -7273,6 +7276,7 @@ actions:
 
   stata_cox_ipw-cohort_prevax-main_preex_TRUE-ild:
     run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-main_preex_TRUE-ild
+      1;28;183;365;730;1095;1460;1825;1979 2020-01-01
     needs:
     - ready-cohort_prevax-main_preex_TRUE-ild
     outputs:
@@ -7296,6 +7300,7 @@ actions:
 
   stata_cox_ipw-cohort_prevax-main_preex_TRUE-pneumonia:
     run: stata-mp:latest analysis/model/cox_model.do cohort_prevax-main_preex_TRUE-pneumonia
+      1;28;183;365;730;1095;1460;1825;1979 2020-01-01
     needs:
     - ready-cohort_prevax-main_preex_TRUE-pneumonia
     outputs:
@@ -7319,6 +7324,7 @@ actions:
 
   stata_cox_ipw-cohort_unvax-main_preex_TRUE-ild:
     run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-main_preex_TRUE-ild
+      1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-main_preex_TRUE-ild
     outputs:
@@ -7342,6 +7348,7 @@ actions:
 
   stata_cox_ipw-cohort_unvax-main_preex_TRUE-pneumonia:
     run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-main_preex_TRUE-pneumonia
+      1;28;183;365;730;1095;1460 2021-06-01
     needs:
     - ready-cohort_unvax-main_preex_TRUE-pneumonia
     outputs:


### PR DESCRIPTION
- Add arguments for cut points and study start so they do not need to be hard coded
- `stset` data using the cut points and study start arguments
- Generate indicator variables for each time period using the cut points argument
- Calculate `outcome_time_median` using the cut points rather than hard coding