### PR TITLE
move four insufficient-event models to R

### DIFF
--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -47,7 +47,16 @@ excluded_models <- c()
 # List of models that should run in Stata due to convergence issues
 
 stata_models <- c(
-  active_analyses$name[grepl("pneumonia", active_analyses$name)],
+  active_analyses$name[
+    grepl("pneumonia", active_analyses$name) &
+      !active_analyses$name %in%
+        c(
+          "cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia",
+          "cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia",
+          "cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia",
+          "cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia"
+        )
+  ],
   "cohort_prevax-main_preex_FALSE-copd",
   "cohort_prevax-sub_covidhospital_TRUE_preex_FALSE-ild",
   "cohort_vax-sub_covidhospital_TRUE_preex_FALSE-ild",

--- a/project.yaml
+++ b/project.yaml
@@ -8987,54 +8987,6 @@ actions:
       moderately_sensitive:
         model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-pneumonia.csv
 
-  ready-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia:
-    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia.rds
-      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
-      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_ckd;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_depression;cov_bin_copd;cov_bin_stroke_isch;cov_bin_pneumonia;cov_bin_asthma;cov_bin_ild
-      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
-      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
-      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
-      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia.dta
-      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia.csv
-    needs:
-    - make_model_input-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia
-    outputs:
-      highly_sensitive:
-        ready: output/model/ready-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia.dta
-
-  stata_cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia
-      1;28;183;365;730;1095;1460 2021-06-01
-    needs:
-    - ready-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia
-    outputs:
-      moderately_sensitive:
-        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia.csv
-
-  ready-cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia:
-    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia.rds
-      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
-      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_ckd;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_depression;cov_bin_copd;cov_bin_stroke_isch;cov_bin_pneumonia;cov_bin_asthma;cov_bin_ild
-      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
-      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
-      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
-      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia.dta
-      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia.csv
-    needs:
-    - make_model_input-cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia
-    outputs:
-      highly_sensitive:
-        ready: output/model/ready-cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia.dta
-
-  stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia
-      1;28;183;365;730;1095;1460 2021-06-01
-    needs:
-    - ready-cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia
-    outputs:
-      moderately_sensitive:
-        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia.csv
-
   ready-cohort_prevax-sub_ethnicity_other_preex_FALSE-pneumonia:
     run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_other_preex_FALSE-pneumonia.rds
       --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
@@ -9130,54 +9082,6 @@ actions:
     outputs:
       moderately_sensitive:
         model_output: output/model/stata_model_output-cohort_prevax-sub_ethnicity_other_preex_TRUE-pneumonia.csv
-
-  ready-cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia:
-    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia.rds
-      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
-      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_ckd;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_depression;cov_bin_copd;cov_bin_stroke_isch;cov_bin_pneumonia;cov_bin_asthma;cov_bin_ild
-      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
-      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
-      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
-      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia.dta
-      --run_analysis=FALSE --df_output=model/model_output-cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia.csv
-    needs:
-    - make_model_input-cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia
-    outputs:
-      highly_sensitive:
-        ready: output/model/ready-cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia.dta
-
-  stata_cox_ipw-cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia
-      1;28;183;365;730;1095;1460 2021-06-01
-    needs:
-    - ready-cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia
-    outputs:
-      moderately_sensitive:
-        model_output: output/model/stata_model_output-cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia.csv
-
-  ready-cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia:
-    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia.rds
-      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
-      --covariate_sex=cov_cat_sex --covariate_age=cov_num_age --covariate_other=cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_ckd;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_depression;cov_bin_copd;cov_bin_stroke_isch;cov_bin_pneumonia;cov_bin_asthma;cov_bin_ild
-      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
-      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
-      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
-      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia.dta
-      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia.csv
-    needs:
-    - make_model_input-cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia
-    outputs:
-      highly_sensitive:
-        ready: output/model/ready-cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia.dta
-
-  stata_cox_ipw-cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia
-      1;28;183;365;730;1095;1460 2021-06-01
-    needs:
-    - ready-cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia
-    outputs:
-      moderately_sensitive:
-        model_output: output/model/stata_model_output-cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia.csv
 
   ready-cohort_prevax-sub_ethnicity_white_preex_FALSE-pneumonia:
     run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_ethnicity_white_preex_FALSE-pneumonia.rds
@@ -10500,7 +10404,9 @@ actions:
     - cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_FALSE-ild
     - cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-ild
     - cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-ild
+    - cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia
     - cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_TRUE-ild
+    - cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia
     - cox_ipw-cohort_prevax-sub_ethnicity_other_preex_FALSE-asthma
     - cox_ipw-cohort_prevax-sub_ethnicity_other_preex_FALSE-copd
     - cox_ipw-cohort_prevax-sub_ethnicity_other_preex_FALSE-ild
@@ -10512,7 +10418,9 @@ actions:
     - cox_ipw-cohort_vax-sub_ethnicity_other_preex_FALSE-ild
     - cox_ipw-cohort_prevax-sub_ethnicity_other_preex_TRUE-ild
     - cox_ipw-cohort_unvax-sub_ethnicity_other_preex_TRUE-ild
+    - cox_ipw-cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia
     - cox_ipw-cohort_vax-sub_ethnicity_other_preex_TRUE-ild
+    - cox_ipw-cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia
     - cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-asthma
     - cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-copd
     - cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-ild
@@ -10544,14 +10452,10 @@ actions:
     - stata_cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_FALSE-pneumonia
     - stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_FALSE-pneumonia
     - stata_cox_ipw-cohort_prevax-sub_ethnicity_mixed_preex_TRUE-pneumonia
-    - stata_cox_ipw-cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia
-    - stata_cox_ipw-cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia
     - stata_cox_ipw-cohort_prevax-sub_ethnicity_other_preex_FALSE-pneumonia
     - stata_cox_ipw-cohort_unvax-sub_ethnicity_other_preex_FALSE-pneumonia
     - stata_cox_ipw-cohort_vax-sub_ethnicity_other_preex_FALSE-pneumonia
     - stata_cox_ipw-cohort_prevax-sub_ethnicity_other_preex_TRUE-pneumonia
-    - stata_cox_ipw-cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia
-    - stata_cox_ipw-cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia
     - stata_cox_ipw-cohort_prevax-sub_ethnicity_white_preex_FALSE-pneumonia
     - stata_cox_ipw-cohort_unvax-sub_ethnicity_white_preex_FALSE-copd
     - stata_cox_ipw-cohort_unvax-sub_ethnicity_white_preex_FALSE-pneumonia


### PR DESCRIPTION
This PR moves four models (pneumonia) with insufficient events to R. They were previously run in Stata by mistake (we put all pneumonia models to Stata), which caused a no output error and stopped the downstream pipeline.