### PR TITLE
Exclude one model

### DIFF
--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -54,7 +54,8 @@ stata_models <- unique(c(
           "cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia",
           "cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia",
           "cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia",
-          "cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia"
+          "cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia",
+          "cohort_vax-sub_sex_female_preex_FALSE-pneumonia"
         )
   ],
   "cohort_prevax-main_preex_FALSE-copd",

--- a/analysis/create_project_actions.R
+++ b/analysis/create_project_actions.R
@@ -42,7 +42,7 @@ describe <- FALSE # This prints descriptive files for each dataset in the pipeli
 
 # List of models excluded from model output generation
 
-excluded_models <- c()
+excluded_models <- c("cohort_vax-sub_sex_female_preex_FALSE-pneumonia")
 
 # List of models that should run in Stata due to convergence issues
 
@@ -54,8 +54,7 @@ stata_models <- unique(c(
           "cohort_unvax-sub_ethnicity_mixed_preex_TRUE-pneumonia",
           "cohort_unvax-sub_ethnicity_other_preex_TRUE-pneumonia",
           "cohort_vax-sub_ethnicity_mixed_preex_TRUE-pneumonia",
-          "cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia",
-          "cohort_vax-sub_sex_female_preex_FALSE-pneumonia"
+          "cohort_vax-sub_ethnicity_other_preex_TRUE-pneumonia"
         )
   ],
   "cohort_prevax-main_preex_FALSE-copd",
@@ -507,7 +506,13 @@ make_model_output <- function(subgroup) {
         ) {
           paste0(
             "stata_cox_ipw-",
-            stata$name[str_detect(stata$analysis, subgroup)]
+            setdiff(
+              stata$name[str_detect(
+                stata$analysis,
+                subgroup
+              )],
+              excluded_models
+            )
           )
         } else {
           character(0)

--- a/project.yaml
+++ b/project.yaml
@@ -10403,30 +10403,6 @@ actions:
       moderately_sensitive:
         model_output: output/model/stata_model_output-cohort_unvax-sub_sex_female_preex_FALSE-pneumonia.csv
 
-  ready-cohort_vax-sub_sex_female_preex_FALSE-pneumonia:
-    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_sex_female_preex_FALSE-pneumonia.rds
-      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
-      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_ckd;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_depression;cov_bin_stroke_isch;cov_bin_pneumonia;cov_bin_ild
-      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
-      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
-      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
-      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_sex_female_preex_FALSE-pneumonia.dta
-      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_sex_female_preex_FALSE-pneumonia.csv
-    needs:
-    - make_model_input-cohort_vax-sub_sex_female_preex_FALSE-pneumonia
-    outputs:
-      highly_sensitive:
-        ready: output/model/ready-cohort_vax-sub_sex_female_preex_FALSE-pneumonia.dta
-
-  stata_cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-pneumonia:
-    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_sex_female_preex_FALSE-pneumonia
-      1;28;183;365;730;1095;1460 2021-06-01
-    needs:
-    - ready-cohort_vax-sub_sex_female_preex_FALSE-pneumonia
-    outputs:
-      moderately_sensitive:
-        model_output: output/model/stata_model_output-cohort_vax-sub_sex_female_preex_FALSE-pneumonia.csv
-
   ready-cohort_prevax-sub_sex_female_preex_TRUE-ild:
     run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_sex_female_preex_TRUE-ild.rds
       --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
@@ -12184,6 +12160,7 @@ actions:
     - cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-asthma
     - cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-copd
     - cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-ild
+    - cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-pneumonia
     - cox_ipw-cohort_vax-sub_sex_female_preex_TRUE-ild
     - cox_ipw-cohort_prevax-sub_sex_male_preex_FALSE-asthma
     - cox_ipw-cohort_unvax-sub_sex_male_preex_FALSE-asthma
@@ -12194,7 +12171,6 @@ actions:
     - stata_cox_ipw-cohort_prevax-sub_sex_female_preex_FALSE-pneumonia
     - stata_cox_ipw-cohort_unvax-sub_sex_female_preex_FALSE-ild
     - stata_cox_ipw-cohort_unvax-sub_sex_female_preex_FALSE-pneumonia
-    - stata_cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-pneumonia
     - stata_cox_ipw-cohort_prevax-sub_sex_female_preex_TRUE-ild
     - stata_cox_ipw-cohort_prevax-sub_sex_female_preex_TRUE-pneumonia
     - stata_cox_ipw-cohort_unvax-sub_sex_female_preex_TRUE-ild

--- a/project.yaml
+++ b/project.yaml
@@ -10403,6 +10403,30 @@ actions:
       moderately_sensitive:
         model_output: output/model/stata_model_output-cohort_unvax-sub_sex_female_preex_FALSE-pneumonia.csv
 
+  ready-cohort_vax-sub_sex_female_preex_FALSE-pneumonia:
+    run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_vax-sub_sex_female_preex_FALSE-pneumonia.rds
+      --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
+      --covariate_sex=NULL --covariate_age=cov_num_age --covariate_other=cov_cat_ethnicity;cov_cat_imd;cov_num_consrate2019;cov_bin_hcworker;cov_cat_smoking;cov_bin_carehome;cov_bin_obesity;cov_bin_ami;cov_bin_dementia;cov_bin_liver_disease;cov_bin_ckd;cov_bin_cancer;cov_bin_hypertension;cov_bin_diabetes;cov_bin_depression;cov_bin_stroke_isch;cov_bin_pneumonia;cov_bin_ild
+      --cox_start=index_date --cox_stop=end_date_outcome --study_start=2021-06-01
+      --study_stop=2025-05-31 --cut_points=1;28;183;365;730;1095;1460 --controls_per_case=20
+      --total_event_threshold=50 --episode_event_threshold=5 --covariate_threshold=5
+      --age_spline=TRUE --save_analysis_ready=model/ready-cohort_vax-sub_sex_female_preex_FALSE-pneumonia.dta
+      --run_analysis=FALSE --df_output=model/model_output-cohort_vax-sub_sex_female_preex_FALSE-pneumonia.csv
+    needs:
+    - make_model_input-cohort_vax-sub_sex_female_preex_FALSE-pneumonia
+    outputs:
+      highly_sensitive:
+        ready: output/model/ready-cohort_vax-sub_sex_female_preex_FALSE-pneumonia.dta
+
+  stata_cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-pneumonia:
+    run: stata-mp:latest analysis/model/cox_model.do cohort_vax-sub_sex_female_preex_FALSE-pneumonia
+      1;28;183;365;730;1095;1460 2021-06-01
+    needs:
+    - ready-cohort_vax-sub_sex_female_preex_FALSE-pneumonia
+    outputs:
+      moderately_sensitive:
+        model_output: output/model/stata_model_output-cohort_vax-sub_sex_female_preex_FALSE-pneumonia.csv
+
   ready-cohort_prevax-sub_sex_female_preex_TRUE-ild:
     run: cox-ipw:v0.0.37 --df_input=model/model_input-cohort_prevax-sub_sex_female_preex_TRUE-ild.rds
       --ipw=TRUE --exposure=exp_date --outcome=out_date --strata=strat_cat_region
@@ -12160,7 +12184,6 @@ actions:
     - cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-asthma
     - cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-copd
     - cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-ild
-    - cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-pneumonia
     - cox_ipw-cohort_vax-sub_sex_female_preex_TRUE-ild
     - cox_ipw-cohort_prevax-sub_sex_male_preex_FALSE-asthma
     - cox_ipw-cohort_unvax-sub_sex_male_preex_FALSE-asthma


### PR DESCRIPTION
This PR excludes the model `stata_cox_ipw-cohort_vax-sub_sex_female_preex_FALSE-pneumonia` that failed in Stata, likely due to collinearity.